### PR TITLE
Fix failing persisting test in QA, because of difference in case of c…

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -810,7 +810,7 @@ def the_vaccinated_values_should_persist(shared_data):
     attach_screenshot("patient_vaccinated_value_must_persist")
     assert format_date(get_vaccination_date(), config["browser"]) == shared_data["vaccination_date"]
     attach_screenshot("vaccination_date_should_persist")
-    assert get_vaccination_care_model_value_on_vaccinated_page() == shared_data["care_model"]
+    assert get_vaccination_care_model_value_on_vaccinated_page().lower() == shared_data["care_model"].lower()
     attach_screenshot("care_model_value_should_persist")
     assert get_vaccinator_value_on_vaccinated_page() == shared_data['vaccinator']
     attach_screenshot("vaccinator_value_should_persist")


### PR DESCRIPTION
…aremodel - Hospital hub

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
